### PR TITLE
Update to 0.22.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "qiskit-terra" %}
-{% set version = "0.22.1" %}
+{% set version = "0.22.3" %}
 
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/qiskit-terra-{{ version }}.tar.gz
-  sha256: d1a4d885f64b7e5b17ad2cef6e07ecd45273136049f2d845f09dfa0703aed361
+  sha256: 4dfd246177883c6d1908ff532e384e9ae063ceb61236833ad656e2da9953a387
 
 build:
   number: 0
@@ -41,7 +41,7 @@ requirements:
     - python-symengine >=0.9
     - shared-memory38  # [py==37]
     - typing-extensions  # [py==37]
-    - tweedledum >=1.1,<2.0
+    - tweedledum >=1.1,<2.0  # [py<311]
   run_constrained:
     - matplotlib >=3.3
     - matplotlib-base >=3.3


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Looking at the status of things in conda-forge, I believe the reason the bot hasn't tried to update this package or rebuild it for 3.11 is that tweedledum has not been built for 3.11 yet ([here](https://github.com/conda-forge/tweedledum-feedstock/pull/4)). qiskit-terra officially added support for 3.11 in 0.22.2 and one of the things it did for that was drop the tweedledum dependency for 3.11 (see [here](https://github.com/Qiskit/qiskit-terra/pull/9071)). The plan is to drop tweedledum entirely for 0.23.