### PR TITLE
Limit importlib-metadata pin to Python 3.8

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BastianZim
+* @BastianZim @wshanks

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -24,9 +24,9 @@ source ${MINIFORGE_HOME}/etc/profile.d/conda.sh
 conda activate base
 
 mamba install --update-specs --quiet --yes --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
+    conda-build pip boa conda-forge-ci-setup=3
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About qiskit-terra
-==================
+About qiskit-terra-feedstock
+============================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/qiskit-terra-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/Qiskit/qiskit-terra
 
 Package license: Apache-2.0
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/qiskit-terra-feedstock/blob/main/LICENSE.txt)
 
 Summary: Software for developing quantum computing programs
 

--- a/README.md
+++ b/README.md
@@ -268,4 +268,5 @@ Feedstock Maintainers
 =====================
 
 * [@BastianZim](https://github.com/BastianZim/)
+* [@wshanks](https://github.com/wshanks/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,3 +74,4 @@ about:
 extra:
   recipe-maintainers:
     - BastianZim
+    - wshanks

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 15147948698eae17d0afb099d1540b22333dae587485595bd5cd3c09d34ab0b6
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   script:
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
@@ -30,7 +30,7 @@ requirements:
     - setuptools-rust
     - wheel
   run:
-    - importlib-metadata <5.0
+    - importlib-metadata <5.0  # [py<39]
     - rustworkx >=0.12.0
     - python
     - numpy >=1.17


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR primarily limits the importlib-metadata requirement to Python <= 3.8 so that it does not interfere with other packages like (tox) that require importlib-metadata >= 6. It also adds me as a maintainer.
